### PR TITLE
Issue 10: Mounting a Blob fails

### DIFF
--- a/aioli.worker.js
+++ b/aioli.worker.js
@@ -104,8 +104,13 @@ API = {
             try {
                 FS.unmount(DIR_DATA_FILES);
             } catch(e) {}
-            FILES.push(file.file);
-            FS.mount(WORKERFS, { files: FILES }, DIR_DATA_FILES);
+            FILES.push(file);
+
+            // Handle File and Blob objects
+            FS.mount(WORKERFS, {
+                files: FILES.filter(f => f.file instanceof File).map(f => f.file),
+                blobs: FILES.filter(f => f.file instanceof Blob).map(f => ({ name: f.name, data: f.file }))
+            }, DIR_DATA_FILES);
         }
 
         // Support URLs


### PR DESCRIPTION
This PR fixes issue #10 by treating Blob objects differently from File objects--Blob objects don't have a `name` attribute, so we need to specify one to Emscripten FS.