### PR TITLE
Issue 12: Mounting a URL fails

### DIFF
--- a/aioli.js
+++ b/aioli.js
@@ -222,12 +222,12 @@ class Aioli
         // Handle URLs
         else if(typeof file == "string" && file.startsWith("http"))
         {
-            // Set defaults
-            name = name || url.split("").pop();
+            // Set defaults (if no name provided: "https://website.com/some/path.js" mounts to "/urls/website.com-some-path.js")
+            name = name || file.split("//").pop().replace(/\//g, "-");
             directory = directory || Aioli.config.dirURLs;
 
             // For URLs, we just use an object, not a File object
-            mountedFile.url = url;
+            mountedFile.url = file;
             mountedFile.source = "url";
         }
 


### PR DESCRIPTION
This PR fixes issue #12 by fixing a typo (`url` should have been `file`).

This PR also adjusts the default mount path for URLs if the user doesn't provide a desired file name. This is done to avoid filename clashes:

* `https://website.com/some/path.js` mounts as `/urls/website.com-some-path.js`
* `https://website2.com/some/path.js` mounts as `/urls/website2.com-some-path.js`

(previously, they would both be mounted as `path.js`, which is confusing.