### PR TITLE
Issue 11: Support custom FS commands

### DIFF
--- a/aioli.js
+++ b/aioli.js
@@ -164,6 +164,21 @@ class Aioli
         return this.send("download", path);
     }
 
+    // Custom file system operations. For example:
+    //   FS.readFile("/file.txt", { encoding: "utf8" });
+    // becomes:
+    //   aioli.fs("readFile", "/file.txt", { encoding: "utf8" })
+    // Supported FS operations: <https://emscripten.org/docs/api_reference/Filesystem-API.html>
+    fs()
+    {
+        // Convert function arguments into array (`arguments` is an object)
+        let args = [...arguments];
+        return this.send("fs", {
+            fn: args.shift(),
+            args: args
+        });
+    }
+
     // =========================================================================
     // Worker Management: Track workers that Aioli is managing so that e.g. it
     // can be notified when a new file is mounted

--- a/aioli.worker.js
+++ b/aioli.worker.js
@@ -84,7 +84,7 @@ API = {
                 response = "ok";
             return response;    
         } catch(err) {
-            console.error(`[AioliWorker] Failed to run FS.${fn}(): ${err}`);
+            console.error(`[AioliWorker] Failed to run FS.${fn}(${args}): ${err}`);
             return "error";
         }
     },

--- a/aioli.worker.js
+++ b/aioli.worker.js
@@ -75,10 +75,18 @@ API = {
     fs: (id, config) => {
         let fn = config.fn;
         let args = config.args;
-        let response = FS[fn](...args);
-        if(response == null)
-            response = "ok";
-        return response;
+        
+        try {
+            if(!(fn in FS))
+                throw `Invalid function ${fn}. See <https://emscripten.org/docs/api_reference/Filesystem-API.html> for valid functions.`;
+            let response = FS[fn](...args);
+            if(response == null)
+                response = "ok";
+            return response;    
+        } catch(err) {
+            console.error(`[AioliWorker] Failed to run FS.${fn}(): ${err}`);
+            return "error";
+        }
     },
 
     // -------------------------------------------------------------------------

--- a/aioli.worker.js
+++ b/aioli.worker.js
@@ -72,6 +72,15 @@ API = {
         return URL.createObjectURL(blob);
     },
 
+    fs: (id, config) => {
+        let fn = config.fn;
+        let args = config.args;
+        let response = FS[fn](...args);
+        if(response == null)
+            response = "ok";
+        return response;
+    },
+
     // -------------------------------------------------------------------------
     // Call main function with custom command
     // -------------------------------------------------------------------------


### PR DESCRIPTION
This PR addresses issue #11, by adding support for arbitrary Emscripten FS commands (currently only support `ls`, `cat`, `download`).

Functions supported: https://emscripten.org/docs/api_reference/Filesystem-API.html
