### PR TITLE
Issue 8: Default to using latest Aioli 

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Here is a simple example of Aioli in action running the genomics tool `samtools`
 
 ```html
 <input id="myfile" type="file" multiple>
-<script src="https://cdn.sandbox.bio/aioli/1.2.0/aioli.js"></script>
+<script src="https://cdn.sandbox.bio/aioli/latest/aioli.js"></script>
 
 <script>
 let samtools = new Aioli("samtools/1.10");

--- a/aioli.js
+++ b/aioli.js
@@ -30,7 +30,7 @@ class Aioli
             dirURLs: "/urls",
             // URLs to code
             urlModules: "https://cdn.sandbox.bio",
-            urlWorkerJS: "https://cdn.sandbox.bio/aioli/1.2.0/aioli.worker.js",
+            urlWorkerJS: "https://cdn.sandbox.bio/aioli/latest/aioli.worker.js",
         }
     }
 
@@ -219,7 +219,7 @@ class Aioli
 
         // Input validation
         if(directory == Aioli.config.dirFiles || directory == Aioli.config.dirURLs)
-            throw "Can't mount a file to a systeam directory.";
+            throw "Can't mount a file to a system directory.";
 
         // Handle File and Blob objects
         if(file instanceof File || file instanceof Blob)


### PR DESCRIPTION
This PR addresses issue #8 by defaulting the Aioli version to `latest` to avoid having to update several files before deploying new Aioli versions.
