### PR TITLE
Issue 9: Support fetching files from non-CDN sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ samtools
     // Initialize samtools
     .init()
     // Run "samtools view" command with "-q 20" filter
-    .then(d => samtools.exec("view -q 20 /samtools/examples/toy.sam"))
+    .then(() => samtools.exec("view -q 20 /samtools/examples/toy.sam"))
     // Output result
     .then(d => document.write(`<pre>${d.stdout}</pre>`));
 </script>
@@ -62,7 +62,7 @@ function loadFile(event)
         // First mount the file
         .mount(event.target.files[0])
         // Once it's mounted, run samtools view
-        .then(file => samtools.exec(`view -q20 ${file.path}`))
+        .then(f => samtools.exec(`view -q20 ${f.path}`))
         // Capture output
         .then(d => console.log(d.stdout));
 }

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/@biowasm/aioli)](https://www.npmjs.com/package/@biowasm/aioli)
 
-Aioli is a framework for building fast genomics web tools using [WebAssembly](https://developer.mozilla.org/en-US/docs/WebAssembly) and WebWorkers.
+Aioli is a framework for building fast genomics web tools using [WebAssembly](https://developer.mozilla.org/en-US/docs/WebAssembly) and [WebWorkers](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API).
 
 ## Tools that use Aioli
 
@@ -13,11 +13,34 @@ Aioli is a framework for building fast genomics web tools using [WebAssembly](ht
 
 ## Getting Started
 
-Here is a simple example of Aioli in action running the genomics tool `samtools` on a user-provided file:
+As shown below, **you can obtain Aioli from our biowasm CDN**, or you can install it from npm: `npm install @biowasm/aioli` (use the npm option if you want to host Aioli module locally).
+
+### A simple example
+
+Here is a simple example of Aioli in action running the genomics tool `samtools` on a small `SAM` file:
+
+```html
+<script src="https://cdn.biowasm.com/aioli/latest/aioli.js"></script>
+<script>
+let samtools = new Aioli("samtools/1.10");
+
+samtools
+    .init()
+    .then(() => {
+        console.log("samtools is initialized");
+
+        // Run samtools view command
+        samtools.exec("view -q 20 /samtools/examples/toy.sam")
+                .then(d => console.log(d.stdout));
+    });
+</script>
+```
+
+### Working with user files
 
 ```html
 <input id="myfile" type="file" multiple>
-<script src="https://cdn.sandbox.bio/aioli/latest/aioli.js"></script>
+<script src="https://cdn.biowasm.com/aioli/latest/aioli.js"></script>
 
 <script>
 let samtools = new Aioli("samtools/1.10");
@@ -44,16 +67,55 @@ document.getElementById("myfile").addEventListener("change", loadFile, false);
 </script>
 ```
 
-You can also install Aioli through npm: `npm install @biowasm/aioli`.
 
+## Aioli Configuration
+
+### Simple
+
+```javascript
+// -------------------------------------
+// Format: <module>/<version>
+// -------------------------------------
+
+// Retrieve specific version (recommended for stability)
+new Aioli("seqtk/1.2");
+
+// Retrieve latest version
+new Aioli("seqtk/latest");
+
+
+// -------------------------------------
+// Format: <module>/<program>/<version>
+// -------------------------------------
+
+// For most bioinformatics tools, <module> == <program>
+new Aioli("seqtk/seqtk/1.2");
+
+// But not always! Some bioinformatics tools have multiple tools
+new Aioli("seq-align/smith_waterman/1.2");
+```
+
+### Advanced
+
+By default, Aioli retrieves the `.wasm` modules and the Aioli WebWorker code from the biowasm CDN for convenience, but you can also load files from local sources:
+
+```javascript
+new Aioli({
+    module: "seq-align",
+    program: "smith_waterman",              // optional (defaults to $module)
+    version: "latest",                      // optional (defaults to latest)
+    urlModule: "./path/to/wasm/files/",     // optional (defaults to biowasm CDN)
+    urlAioli: "./path/to/aioli.worker.js",  // optional (defaults to biowasm CDN)
+});
+```
 
 ## Background info
 
 ### What is WebAssembly?
-[WebAssembly](https://developer.mozilla.org/en-US/docs/WebAssembly) is a very fast, low-level, compiled binary instruction format that runs in all major browsers at near native speeds.
+[WebAssembly](https://developer.mozilla.org/en-US/docs/WebAssembly) is a fast, low-level, compiled binary instruction format that runs in all major browsers at near native speeds. One key feature of WebAssembly is code reuse: you can port existing C/C++/Rust/etc tools to WebAssembly so those tools can run in the browser.
 
 ### What is a WebWorker?
 [WebWorkers](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API) allow you to run JavaScript in the browser in a background thread, which keeps the browser responsive.
 
 ### Compiling into WebAssembly
-See the [biowasm](https://github.com/biowasm/biowasm/) repository.
+See the [biowasm](https://github.com/biowasm/biowasm/) project.

--- a/README.md
+++ b/README.md
@@ -26,15 +26,14 @@ Here's Aioli in action running the genomics tool `samtools` on a small `SAM` fil
 <script>
 let samtools = new Aioli("samtools/1.10");
 
+document.write("Loading...");
 samtools
+    // Initialize samtools
     .init()
-    .then(() => {
-        console.log("samtools is initialized");
-
-        // Run samtools view command
-        samtools.exec("view -q 20 /samtools/examples/toy.sam")
-                .then(d => console.log(d.stdout));
-    });
+    // Run "samtools view" command with "-q 20" filter
+    .then(d => samtools.exec("view -q 20 /samtools/examples/toy.sam"))
+    // Output result
+    .then(d => document.write(`<pre>${d.stdout}</pre>`));
 </script>
 ```
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Here is a simple example of Aioli in action running the genomics tool `samtools`
 
 ```html
 <input id="myfile" type="file" multiple>
-<script src="https://cdn.sandbox.bio/aioli/1.1.0/aioli.js"></script>
+<script src="https://cdn.sandbox.bio/aioli/1.2.0/aioli.js"></script>
 
 <script>
 let samtools = new Aioli("samtools/1.10");

--- a/README.md
+++ b/README.md
@@ -2,22 +2,24 @@
 
 [![npm](https://img.shields.io/npm/v/@biowasm/aioli)](https://www.npmjs.com/package/@biowasm/aioli)
 
-Aioli is a framework for building fast genomics web tools using [WebAssembly](https://developer.mozilla.org/en-US/docs/WebAssembly) and [WebWorkers](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API).
+Aioli is a framework for building fast genomics web applications using [WebAssembly](https://developer.mozilla.org/en-US/docs/WebAssembly) and [WebWorkers](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API).
 
-## Tools that use Aioli
+## Tools using Aioli
 
-- [fastq.bio](https://github.com/robertaboukhalil/fastq.bio)
-- [bam.bio](https://github.com/robertaboukhalil/bam.bio)
-- [genomeribbon.com](https://github.com/MariaNattestad/Ribbon)
-- [alignment.sandbox.bio](https://github.com/robertaboukhalil/alignment-sandbox)
+| Tool | URL | Repo |
+|-|-|-|
+| Ribbon | [genomeribbon.com](https://genomeribbon.com) | [MariaNattestad/Ribbon](https://github.com/MariaNattestad/Ribbon) |
+| Alignment Sandbox | [alignment.sandbox.bio](https://alignment.sandbox.bio/) | [RobertAboukhalil/alignment-sandbox](https://github.com/robertaboukhalil/alignment-sandbox) |
+| fastq.bio | [fastq.bio](http://www.fastq.bio/) | [RobertAboukhalil/fastq.bio](https://github.com/robertaboukhalil/fastq.bio) |
+| bam.bio | [bam.bio](http://www.bam.bio/) | [RobertAboukhalil/bam.bio](https://github.com/robertaboukhalil/bam.bio) |
 
 ## Getting Started
 
-As shown below, **you can obtain Aioli from our biowasm CDN**, or you can install it from npm: `npm install @biowasm/aioli` (use the npm option if you want to host Aioli module locally).
+As shown below, **you can obtain Aioli from our biowasm CDN**, or you can install it from npm: `npm install @biowasm/aioli` (use the `npm` option if you need to host the Aioli module locally).
 
 ### A simple example
 
-Here is a simple example of Aioli in action running the genomics tool `samtools` on a small `SAM` file:
+Here's Aioli in action running the genomics tool `samtools` on a small `SAM` file:
 
 ```html
 <script src="https://cdn.biowasm.com/aioli/latest/aioli.js"></script>
@@ -38,10 +40,12 @@ samtools
 
 ### Working with user files
 
+We can update the previous example to run `samtools` on a file provided by the user:
+
 ```html
 <input id="myfile" type="file" multiple>
-<script src="https://cdn.biowasm.com/aioli/latest/aioli.js"></script>
 
+<script src="https://cdn.biowasm.com/aioli/latest/aioli.js"></script>
 <script>
 let samtools = new Aioli("samtools/1.10");
 
@@ -91,8 +95,9 @@ new Aioli("seqtk/latest");
 // For most bioinformatics tools, <module> == <program>
 new Aioli("seqtk/seqtk/1.2");
 
-// But not always! Some bioinformatics tools have multiple tools
+// But not always! Some tools have multiple sub-tools
 new Aioli("seq-align/smith_waterman/1.2");
+new Aioli("seq-align/needleman_wunsch/1.2");
 ```
 
 ### Advanced

--- a/aioli.js
+++ b/aioli.js
@@ -56,11 +56,11 @@ class Aioli
             program: config.module,
 
             // Separate URLs to make it easier to test modifying Aioli while using the CDN for Wasm modules
-            urlModule: `https://cdn-stg.biowasm.com/${config.module}/${config.version || "latest"}`,
-            urlAioli: "https://cdn-stg.biowasm.com/aioli/latest/aioli.worker.js",  // locally: ./aioli.worker.js
+            urlModule: `https://cdn.biowasm.com/${config.module}/${config.version || "latest"}`,
+            urlAioli: "https://cdn.biowasm.com/aioli/latest/aioli.worker.js",  // to use a local worker.js, specify "./aioli.worker.js"
 
             // Paths on the virtual file system
-            // TODO: allow these to be changes without having to modify aioli.worker.js
+            // TODO: allow these to be changed without having to modify aioli.worker.js
             dirFiles: "/data",
             dirURLs: "/urls",
         };

--- a/aioli.js
+++ b/aioli.js
@@ -32,11 +32,16 @@ class Aioli
     // Create module
     constructor(config)
     {
-        if(typeof config == "string") {
+        // Support "<module>/<version>" or "<module>/<program>/<version>" instead of object config
+        if(typeof config == "string")
+        {
             const configSplit = config.split("/");
+            if(configSplit.length < 2 || configSplit.length > 3)
+                throw `Error: Aioli("${config}") is not valid. Expecting "<module>/<version>" or "<module>/<program>/<version>".`;
             config = {
                 module: configSplit[0],
-                version: configSplit[1] || "latest"
+                program: configSplit.length == 3 ? configSplit[1] : configSplit[0],
+                version: configSplit[configSplit.length - 1],
             };
         }
 

--- a/aioli.js
+++ b/aioli.js
@@ -16,7 +16,7 @@ class Aioli
     //    program: "smith_waterman",              // optional (defaults to $module)
     //    version: "latest",                      // optional (defaults to latest)
     //    urlModule: "./path/to/wasm/files/",     // optional (defaults to biowasm CDN)
-    //    urlAioli: "./path/to/aioli.worker.js",  // optional (defaults to biowasm CDN
+    //    urlAioli: "./path/to/aioli.worker.js",  // optional (defaults to biowasm CDN)
     //  };
 
     // WebWorker:

--- a/aioli.js
+++ b/aioli.js
@@ -14,6 +14,7 @@ class Aioli
     //  config = {          // Config
     //    module: "seq-align",
     //    program: "smith_waterman",
+    //    version: "latest",                      // optional
     //    urlModule: "./path/to/wasm/files/",     // optional
     //    urlAioli: "./path/to/aioli.worker.js",  // optional
     //  };

--- a/aioli.js
+++ b/aioli.js
@@ -32,10 +32,7 @@ class Aioli
     // Create module
     constructor(config)
     {
-        // Backwards compatibility with Aioli <= v1.3.0:
-        // Support Aioli("seqtk/<version>") or Aioli("seqtk")
         if(typeof config == "string") {
-            console.warn("Initializing Aioli() with a string is deprecated. Please initialize with an object. See https://github.com/biowasm/aioli for details.");
             const configSplit = config.split("/");
             config = {
                 module: configSplit[0],

--- a/aioli.js
+++ b/aioli.js
@@ -56,8 +56,8 @@ class Aioli
             program: config.module,
 
             // Separate URLs to make it easier to test modifying Aioli while using the CDN for Wasm modules
-            urlModule: `https://cdn-stg.biowasm.com/${config.module}/${config.version || "latest"}`,
-            urlAioli: "https://cdn-stg.biowasm.com/aioli/latest/aioli.worker.js",  // to use a local worker.js, specify "./aioli.worker.js"
+            urlModule: `https://cdn.biowasm.com/${config.module}/${config.version || "latest"}`,
+            urlAioli: "https://cdn.biowasm.com/aioli/latest/aioli.worker.js",  // to use a local worker.js, specify "./aioli.worker.js"
 
             // Paths on the virtual file system
             // TODO: allow these to be changed without having to modify aioli.worker.js

--- a/aioli.js
+++ b/aioli.js
@@ -13,10 +13,10 @@ class Aioli
     //  ready = false;      // Will be true when the module is ready
     //  config = {          // Config
     //    module: "seq-align",
-    //    program: "smith_waterman",
-    //    version: "latest",                      // optional
-    //    urlModule: "./path/to/wasm/files/",     // optional
-    //    urlAioli: "./path/to/aioli.worker.js",  // optional
+    //    program: "smith_waterman",              // optional (defaults to $module)
+    //    version: "latest",                      // optional (defaults to latest)
+    //    urlModule: "./path/to/wasm/files/",     // optional (defaults to biowasm CDN)
+    //    urlAioli: "./path/to/aioli.worker.js",  // optional (defaults to biowasm CDN
     //  };
 
     // WebWorker:
@@ -32,6 +32,17 @@ class Aioli
     // Create module
     constructor(config)
     {
+        // Backwards compatibility with Aioli <= v1.3.0:
+        // Support Aioli("seqtk/<version>") or Aioli("seqtk")
+        if(typeof config == "string") {
+            console.warn("Initializing Aioli() with a string is deprecated. Please initialize with an object. See https://github.com/biowasm/aioli for details.");
+            const configSplit = config.split("/");
+            config = {
+                module: configSplit[0],
+                version: configSplit[1] || "latest"
+            };
+        }
+
         // Make sure config.module is defined
         if(config.module == null)
             throw "Must specify a `module` name";

--- a/aioli.js
+++ b/aioli.js
@@ -1,6 +1,6 @@
 // Notes:
 // - Files mounted after WebWorkers are initialized will be auto-mounted on each Worker
-// - WebAssembly module and WebWorker initialization code downloaded from cdn.sandbox.bio
+// - WebAssembly module and WebWorker initialization code downloaded from cdn.biowasm.com
 // - Mounting URLs uses lazy-loading to fetch information as needed
 
 class Aioli
@@ -11,7 +11,12 @@ class Aioli
 
     // Module:
     //  ready = false;      // Will be true when the module is ready
-    //  urlModule = "";     // URL path to module
+    //  config = {          // Config
+    //    module: "seq-align",
+    //    program: "smith_waterman",
+    //    urlModule: "./path/to/wasm/files/",     // optional
+    //    urlAioli: "./path/to/aioli.worker.js",  // optional
+    //  };
 
     // WebWorker:
     //  worker = null;      // WebWorker this module communicates with
@@ -20,63 +25,55 @@ class Aioli
     //  callbacks = {};     // Callbacks can be made to send messages without resolving the Promise
 
     // =========================================================================
-    // Configs and defaults
-    // =========================================================================
-
-    static get config() {
-        return {
-            debug: false,
-            // Files on virtual file system
-            dirFiles: "/data",
-            dirURLs: "/urls",
-            // URLs to code
-            urlModules: "https://cdn.sandbox.bio",
-            urlWorkerJS: "https://cdn.sandbox.bio/aioli/latest/aioli.worker.js",
-        }
-    }
-
-    // =========================================================================
     // Initialization
     // =========================================================================
 
     // Create module
-    // e.g. Aioli("samtools/1.10") --> cdn.sandbox.bio/samtools/1.10/worker.{js,wasm}
-    constructor(module)
+    constructor(config)
     {
+        // Make sure config.module is defined
+        if(config.module == null)
+            throw "Must specify a `module` name";
+
+        // Default settings
+        let defaults = {
+            // In most cases, the program is the same as the module, but other times isn't.
+            // e.g. for module=seq-align, program can be "needleman_wunsch", "smith_waterman", or "lcs"
+            program: config.module,
+
+            // Separate URLs to make it easier to test modifying Aioli while using the CDN for Wasm modules
+            urlModule: `https://cdn-stg.biowasm.com/${config.module}/${config.version || "latest"}`,
+            urlAioli: "https://cdn-stg.biowasm.com/aioli/latest/aioli.worker.js",  // locally: ./aioli.worker.js
+
+            // Paths on the virtual file system
+            // TODO: allow these to be changes without having to modify aioli.worker.js
+            dirFiles: "/data",
+            dirURLs: "/urls",
+        };
+        Aioli.config = Object.assign({}, defaults, config);
+
         // Initialize properties
         this.ready = false;
-        this.urlModule = "";
         this.worker = null;
         this.resolves = {};
         this.rejects = {};
         this.callbacks = {};
-
-        // Input validation
-        if(typeof module != "string")
-            throw "Must provide a string to the Aioli constructor";
-
-        // By default, modules are hosted on sandbox.bio
-        if(!module.startsWith("http"))
-            module = `${Aioli.config.urlModules}/${module}`;
-
-        module += "/worker.js";
-        this.urlModule = module;
     }
 
     // Download module code and launch WebWorker
     async init()
     {
         // Load Aioli worker JS
-        const workerResponse = await fetch(Aioli.config.urlWorkerJS);
+        const workerResponse = await fetch(Aioli.config.urlAioli);
         const workerJS = await workerResponse.text();
 
         // Load compiled .wasm module JS
-        const moduleResponse = await fetch(this.urlModule);
+        const moduleResponse = await fetch(`${Aioli.config.urlModule}/${Aioli.config.program}.js`);
         const moduleJS = await moduleResponse.text();
 
         // Prepend Aioli worker code to the module (one alternative would be to launch an Aioli
         // WebWorker that imports the module code and eval(), but would rather avoid that)
-        const js = workerJS + "\n" + moduleJS;
+        const js = `BIOWASM_URL = "${Aioli.config.urlModule}/";\n${workerJS}\n${moduleJS}`;
         const blob = new Blob([js], { type: "application/javascript" });
         this.worker = new Worker(URL.createObjectURL(blob));
 

--- a/aioli.js
+++ b/aioli.js
@@ -56,8 +56,8 @@ class Aioli
             program: config.module,
 
             // Separate URLs to make it easier to test modifying Aioli while using the CDN for Wasm modules
-            urlModule: `https://cdn.biowasm.com/${config.module}/${config.version || "latest"}`,
-            urlAioli: "https://cdn.biowasm.com/aioli/latest/aioli.worker.js",  // to use a local worker.js, specify "./aioli.worker.js"
+            urlModule: `https://cdn-stg.biowasm.com/${config.module}/${config.version || "latest"}`,
+            urlAioli: "https://cdn-stg.biowasm.com/aioli/latest/aioli.worker.js",  // to use a local worker.js, specify "./aioli.worker.js"
 
             // Paths on the virtual file system
             // TODO: allow these to be changed without having to modify aioli.worker.js

--- a/aioli.worker.js
+++ b/aioli.worker.js
@@ -36,6 +36,21 @@ Module = {
         resolveInitWasm();
     },
 
+    // Load .wasm/.data files from a custom path
+    locateFile: (path, dir) => {
+        var dirRoot = "";
+
+        // Use hardcoded path if `BIOWASM_URL` was defined when creating WebWorker script
+        if(typeof BIOWASM_URL !== 'undefined')
+            dirRoot = BIOWASM_URL;
+        // Or infer it from the path to the JS file
+        else {
+            var dirJS = self.location.href;
+            dirRoot = dirJS.substring(0, dirJS.lastIndexOf("/") + 1);
+        }
+        return dirRoot + path;    
+    },
+
     // Setup print functions to store stdout/stderr based on id
     print: text => STDOUT[MSG_UUID] += `${text}\n`,
     printErr: text => STDERR[MSG_UUID] += `${text}\n`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@biowasm/aioli",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "A framework for building WebAssembly-based genomics tools",
   "main": "aioli.js",
   "repository": {


### PR DESCRIPTION
For convenience, Aioli currently relies on the biowasm CDN to load `.wasm`/`.js`/`.data` files. This PR adds the ability to load those files from custom sources.