### PR TITLE
Modify exec() so we can pass along custom arguments

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -127,15 +127,18 @@ const aioli = {
 	// =========================================================================
 	// Execute a command
 	// =========================================================================
-	async exec(command)
+	async exec(command, args=null)
 	{
 		// Input validation
-		aioli._log(`Executing: %c${command}%c`, "color:darkblue; font-weight:bold");
+		aioli._log(`Executing %c${command}%c args=${args}`, "color:darkblue; font-weight:bold", "");
 		if(!command)
 			throw "Expecting a command";
 		// Extract tool name and arguments
-		const args = command.split(" ");
-		const toolName = args.shift();
+		let toolName = command;
+		if(args == null) {
+			args = command.split(" ");
+			toolName = args.shift();
+		}
 
 		// Does it match a program we've already initialized?
 		const tools = aioli.tools.filter(d => d.program == toolName);


### PR DESCRIPTION
This PR addresses #29 by adding an optional `args` parameter to Aioli's `exec()` function. If `args` is not null, those parameters are provided as is to the module when that module's `main()` function is called.