### PR TITLE
Create separate function for reinit

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -217,19 +217,7 @@ const aioli = {
 		// Reinitialize module after done? This is useful for tools that don't properly reset their global state the
 		// second time the `main()` function is called.
 		if(tool.reinit === true) {
-			// Save state before reinitializing
-			const pwd = aioli.base.module.FS.cwd();
-
-			// Reinitialize module
-			Object.assign(tool, tool.config);
-			tool.ready = false;
-			await this.init();
-			// If reinitialized the base module, remount previously mounted files
-			if(tool.isBaseModule)
-				this.mount();
-
-			// Go back to previous folder
-			this.cd(pwd);
+			await this._reinit(tool);
 		}
 
 		return result;
@@ -455,6 +443,22 @@ const aioli = {
 				fs: fsSrc
 			}, pathDst);
 		}
+	},
+
+	// =========================================================================
+	// Reinitialize a tool
+	// =========================================================================
+	async _reinit(tool) {
+		// Save state before reinitializing
+		const pwd = aioli.base.module.FS.cwd();
+
+		// Reinitialize module
+		Object.assign(tool, tool.config);
+		tool.ready = false;
+		await this.init();
+
+		// Go back to previous folder
+		this.cd(pwd);
 	},
 
 	// =========================================================================

--- a/src/worker.js
+++ b/src/worker.js
@@ -217,7 +217,7 @@ const aioli = {
 		// Reinitialize module after done? This is useful for tools that don't properly reset their global state the
 		// second time the `main()` function is called.
 		if(tool.reinit === true) {
-			await this._reinit(tool.tool);
+			await this.reinit(tool.tool);
 		}
 
 		return result;
@@ -269,6 +269,26 @@ const aioli = {
 		const stream = aioli.fs.open(path, flag);
 		aioli.fs.write(stream, buffer, offset, buffer.length, position);
 		aioli.fs.close(stream);
+	},
+
+	// =========================================================================
+	// Reinitialize a tool
+	// =========================================================================
+	async reinit(toolName) {
+		const tool = aioli.tools.find(t => t.tool == toolName);
+		// Save state before reinitializing
+		const pwd = aioli.base.module.FS.cwd();
+
+		// Reinitialize module
+		Object.assign(tool, tool.config);
+		tool.ready = false;
+		await this.init();
+		// If reinitialized the base module, remount previously mounted files
+		if(tool.isBaseModule)
+			this.mount();
+
+		// Go back to previous folder
+		this.cd(pwd);
 	},
 
 	// =========================================================================
@@ -443,23 +463,6 @@ const aioli = {
 				fs: fsSrc
 			}, pathDst);
 		}
-	},
-
-	// =========================================================================
-	// Reinitialize a tool
-	// =========================================================================
-	async _reinit(toolName) {
-		const tool = aioli.tools.find(t => t.tool == toolName);
-		// Save state before reinitializing
-		const pwd = aioli.base.module.FS.cwd();
-
-		// Reinitialize module
-		Object.assign(tool, tool.config);
-		tool.ready = false;
-		await this.init();
-
-		// Go back to previous folder
-		this.cd(pwd);
 	},
 
 	// =========================================================================

--- a/src/worker.js
+++ b/src/worker.js
@@ -217,7 +217,7 @@ const aioli = {
 		// Reinitialize module after done? This is useful for tools that don't properly reset their global state the
 		// second time the `main()` function is called.
 		if(tool.reinit === true) {
-			await this._reinit(tool);
+			await this._reinit(tool.tool);
 		}
 
 		return result;
@@ -448,7 +448,8 @@ const aioli = {
 	// =========================================================================
 	// Reinitialize a tool
 	// =========================================================================
-	async _reinit(tool) {
+	async _reinit(toolName) {
+		const tool = aioli.tools.find(t => t.tool == toolName);
 		// Save state before reinitializing
 		const pwd = aioli.base.module.FS.cwd();
 


### PR DESCRIPTION
Hi Robert,

To prevent extra memory from being used when running minimap2, I set `reinit: true`. This possibly occurs with other tools, but minimap2 was using extra memory in my case (determined by looking though heap snapshots with chrome dev tools before and after minimap2 was run). After setting `reinit: true`, there would no longer be a memory leak. However, I noticed that if I enabled it, then I wouldn't be able to get a heap snapshot that accurately measured the peak memory being used by the tool (I would run the heap snapshot after the tool finished since the heap snapshot would be stuck at "Snapshotting..." when trying to snapshot in the middle of the tool execution), since the tool would already be reinitialized. As a solution, I moved the reinit code to a separate function, where the user could call it manually as well (instead of the tool automatically cleaning up). Nevertheless, if reinit is set to true in the config, the original behavior is unchanged and it still will be automatically called.

Thank you!
Daniel