### PR TITLE
Do not accumulate stdout/err if streaming

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -376,7 +376,6 @@ const aioli = {
 			},
 			// Setup print functions to store stdout/stderr output
 			print: text => {
-				tool.stdout += text + "\n";
 				if(aioli.config.printStream) {
 					postMessage({
 						type: "biowasm",
@@ -384,11 +383,12 @@ const aioli = {
 							stdout: text,
 						},
 					});
+				} else {
+					tool.stdout += text + "\n";
 				}
 			},
 			printErr: text => {
 				const destination = aioli.config.printInterleaved ? "stdout" : "stderr";
-				tool[destination] += text + "\n";
 				if(aioli.config.printStream) {
 					postMessage({
 						type: "biowasm",
@@ -396,6 +396,8 @@ const aioli = {
 							[destination]: text,
 						},
 					});
+				} else {
+					tool[destination] += text + "\n";
 				}
 			}
 		});


### PR DESCRIPTION
HI @robertaboukhalil,

First up `biowasm` is amazing! I've been using it for a few different projects and really enjoying it. 

I'm trying to process some large files with biowasm tools, however, I'm running into memory issues. I think a simple way reduce the required memory is to process results as a stream i.e. using `printStream: true`. However, `Aioli` currently accumulates stdout/err into tool.stdout/err even when printStream is `true`, thus negating the memory efficiency of streaming. 

In this PR I've changed the behaviour of print and printErr to only accumulate stdout/err if printStream is `false`.

All the best,

Wytamma