### PR TITLE
Add a function "downloadBlob" for zip downloading multiple files and solve multiple space problem in the command arguments

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -238,6 +238,12 @@ const aioli = {
 		return aioli._fileop("download", path);
 	},
 
+	downloadBlob(path) { // return a blob instead of a URL, so it can be downloaded with other files by jszip
+		const file = aioli.fs.readFile(path);
+        const blob = new Blob([ file ]);
+        return blob;
+	},
+
 	pwd() {
 		return aioli.fs.cwd();
 	},

--- a/src/worker.js
+++ b/src/worker.js
@@ -166,7 +166,7 @@ const aioli = {
 		// Extract tool name and arguments
 		let toolName = command;
 		if(args == null) {
-			args = command.split(" ");
+			args = command.trim().split(/ +/); // trim and split by one or more whitespaces to avoid common errors due to extra spaces.
 			toolName = args.shift();
 		}
 

--- a/src/worker.js
+++ b/src/worker.js
@@ -239,9 +239,7 @@ const aioli = {
 	},
 
 	downloadBlob(path) { // return a blob instead of a URL, so it can be downloaded with other files by jszip
-		const file = aioli.fs.readFile(path);
-        const blob = new Blob([ file ]);
-        return blob;
+		return aioli._fileop("downloadBlob", path);
 	},
 
 	pwd() {
@@ -510,6 +508,10 @@ const aioli = {
 			case "download":
 				const blob = new Blob([ this.cat(path) ]);
 				return URL.createObjectURL(blob);
+
+			case "downloadBlob":
+				const file = aioli.fs.readFile(path);
+				return new Blob([ file ]); // return a blob instead of a URL, so it can be downloaded with other files by jszip
 		}
 
 		return false;


### PR DESCRIPTION
I made two modifications:

1. Add a function called "downloadBlob" so I can use jszip to zip multiple files for downloading.
2. Trim spaces and split by `/ +/` to avoid space problems for commands for `CLI.exec`.